### PR TITLE
reviewer interface start -- now need to actually do the JS

### DIFF
--- a/event_exim/models.py
+++ b/event_exim/models.py
@@ -65,8 +65,9 @@ class EventSource(models.Model):
 
    @cached_property
    def api(self):
-      connector_module = importlib.import_module('event_exim.connectors.%s' % self.crm_type)
-      return connector_module.Connector(self)
+      if self.crm_type:
+         connector_module = importlib.import_module('event_exim.connectors.%s' % self.crm_type)
+         return connector_module.Connector(self)
 
    def update_events(self, update_since=None):
       """

--- a/event_review/admin.py
+++ b/event_review/admin.py
@@ -3,7 +3,7 @@ from django import forms
 from django.utils.html import format_html, mark_safe
 
 from event_store.models import Event
-from reviewer.filters import ReviewerOrganizationFilter
+from reviewer.filters import ReviewerOrganizationFilter, review_widget
 from huerta.filters import CollapsedListFilter
 
 def event_list_display(obj):
@@ -17,10 +17,8 @@ def event_list_display(obj):
                 <div><b>Description</b> {description}</div>
             </div>
             <div class="col-md-6">
-                <div><b>Review Status:</b> {review_status}</div>
-                <div><b>Prep Status:</b> {prep_status}</div>
-                <div><b>Active Status:</b> {active_status}</div>
-                <div><b>Notes:</b> {notes}</div>
+                <div><b>Event Status:</b> {active_status}</div>
+                {review_widget}
             </div>
         </div>
         """,
@@ -28,11 +26,12 @@ def event_list_display(obj):
         venue=obj.venue,
         private=mark_safe('<div class="alert alert-danger">Private</div>') if obj.is_private else '',
         host=obj.organization_host,
-        review_status=obj.organization_status_review,
-        prep_status=obj.organization_status_prep,
+        #review_status=obj.organization_status_review,
+        #prep_status=obj.organization_status_prep,
         active_status=obj.status,
-        notes=mark_safe('<textarea rows="5" class="form-control" readonly>%s</textarea>' % obj.notes)
-            if obj.notes else None,
+        review_widget=review_widget(obj),
+        #notes=mark_safe('<textarea rows="5" class="form-control" readonly>%s</textarea>' % obj.notes)
+        #    if obj.notes else None,
         description = mark_safe('<textarea rows="5" class="form-control" readonly>%s</textarea>' % obj.public_description)
             if obj.public_description else None)
 

--- a/event_review/admin.py
+++ b/event_review/admin.py
@@ -3,6 +3,7 @@ from django import forms
 from django.utils.html import format_html, mark_safe
 
 from event_store.models import Event
+from reviewer.filters import ReviewerOrganizationFilter
 from huerta.filters import CollapsedListFilter
 
 def event_list_display(obj):
@@ -37,10 +38,12 @@ def event_list_display(obj):
 
 @admin.register(Event)
 class EventAdmin(admin.ModelAdmin):
+
     disable_list_headers = True
     list_striped = True
     list_display = (event_list_display,)
-    list_filter = (('organization_campaign', CollapsedListFilter),
+    list_filter = (ReviewerOrganizationFilter,
+                   ('organization_campaign', CollapsedListFilter),
                    ('organization_status_review', CollapsedListFilter),
                    ('organization_status_prep', CollapsedListFilter),
                    ('state', CollapsedListFilter),

--- a/eventroller/urls.py
+++ b/eventroller/urls.py
@@ -1,4 +1,5 @@
-from django.conf.urls import include, url
+from django.conf import settings
+from django.conf.urls import include, static, url
 from django.contrib import admin
 
 urlpatterns = [
@@ -9,3 +10,6 @@ urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^review/', include('reviewer.urls')),
 ]
+
+if settings.DEBUG:
+    urlpatterns = urlpatterns + static.static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/reviewer/README.md
+++ b/reviewer/README.md
@@ -1,7 +1,7 @@
-This is a generic reviewing module which comes with some (hacky) javascript to load
-into an admin view.
+If you want to allow the review of your records in admin,
+this is an easy, generic add-on that will work for speed/scale/access-control of reviewers.
 
-In your admin view, you want to:
+To do this, in your admin view:
 
 ```python
 from reviewer.filters import ReviewerOrganizationFilter, review_widget
@@ -20,6 +20,11 @@ FooAdmin(admin.ModelAdmin):
 This was built to review Events (i.e. `event_store.models.Events`) and is tied
 to `event_store.models.Organization`.
 
+Adding the ReviewerOrganizationFilter will, by default, try to filter on a field
+called `organization`.  If the field is something else, subclass ReviewerOrganizationFilter
+and change the class' `fieldname` value.
+
 ## Backend
 
 The api leverages a redis store to queue changes and attention from the frontend.
+

--- a/reviewer/README.md
+++ b/reviewer/README.md
@@ -1,0 +1,25 @@
+This is a generic reviewing module which comes with some (hacky) javascript to load
+into an admin view.
+
+In your admin view, you want to:
+
+```python
+from reviewer.filters import ReviewerOrganizationFilter, review_widget
+```
+
+and then inside your admin hook both of those up like so:
+
+```python
+FooAdmin(admin.ModelAdmin):
+
+   list_filter = (ReviewerOrganizationFilter,
+                  ...)
+   list_display = [..., review_widget]
+```
+
+This was built to review Events (i.e. `event_store.models.Events`) and is tied
+to `event_store.models.Organization`.
+
+## Backend
+
+The api leverages a redis store to queue changes and attention from the frontend.

--- a/reviewer/filters.py
+++ b/reviewer/filters.py
@@ -7,6 +7,9 @@ from django.utils.html import format_html, conditional_escape
 from event_store.models import Organization, EVENT_REVIEW_CHOICES, EVENT_PREP_CHOICES
 from reviewer.models import ReviewGroup
 
+def review_widget(obj):
+    return format_html('<div class="review" data-pk="{}"></div>', obj.id)
+
 class ReviewerOrganizationFilter(SimpleListFilter):
     template = "reviewer/admin/reviewerorganizationfilter.html"
     parameter_name = "org"
@@ -29,16 +32,14 @@ class ReviewerOrganizationFilter(SimpleListFilter):
             return Organization.objects.filter(id=val).first().slug
 
     def review_schema_json(self):
-        return json.dumps({
-            'review_status': {
-                'choices': EVENT_REVIEW_CHOICES,
-                'label': 'Review Status',
-            },
-            'prep_status': {
-                'choices': EVENT_PREP_CHOICES,
-                'label': 'Prep Status',
-            }
-        })
+        return json.dumps([
+            {'name': 'review_status',
+             'choices': EVENT_REVIEW_CHOICES,
+             'label': 'Review Status'},
+            {'name': 'prep_status',
+             'choices': EVENT_PREP_CHOICES,
+             'label': 'Prep Status'},
+        ])
 
     def lookups(self, request, model_admin):
         # we need this to save the right content type with the review api

--- a/reviewer/filters.py
+++ b/reviewer/filters.py
@@ -1,0 +1,54 @@
+import json
+
+from django.contrib.admin.filters import SimpleListFilter
+from django.contrib.contenttypes.models import ContentType
+from django.utils.html import format_html, conditional_escape
+
+from event_store.models import Organization, EVENT_REVIEW_CHOICES, EVENT_PREP_CHOICES
+from reviewer.models import ReviewGroup
+
+class ReviewerOrganizationFilter(SimpleListFilter):
+    template = "reviewer/admin/reviewerorganizationfilter.html"
+    parameter_name = "org"
+    title = "Organization"
+
+    fieldname = 'organization'
+
+    def value(self):
+        """
+        If only one choice, then auto-choose it for the easy/default case
+        """
+        val = super(ReviewerOrganizationFilter, self).value()
+        if not val and len(self.lookup_choices) == 1:
+            val = self.lookup_choices[0][0]
+        return val
+
+    def get_slug(self):
+        val = self.value()
+        if val:
+            return Organization.objects.filter(id=val).first().slug
+
+    def review_schema_json(self):
+        return json.dumps({
+            'review_status': {
+                'choices': EVENT_REVIEW_CHOICES,
+                'label': 'Review Status',
+            },
+            'prep_status': {
+                'choices': EVENT_PREP_CHOICES,
+                'label': 'Prep Status',
+            }
+        })
+
+    def lookups(self, request, model_admin):
+        # we need this to save the right content type with the review api
+        self.content_type = ContentType.objects.get_for_model(model_admin.model)
+        user = request.user
+        return ReviewGroup.user_review_groups(request.user).values_list('organization_id', 'organization__title')
+
+    def queryset(self, request, queryset):
+        org = self.value()
+        if org:
+            filterargs = {self.fieldname: org}
+            return queryset.filter(**filterargs)
+        return queryset

--- a/reviewer/models.py
+++ b/reviewer/models.py
@@ -8,6 +8,9 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 
 from event_store.models import Organization
 
+
+_ORGANIZATIONS = {}  # by slug
+
 class ReviewGroup(models.Model):
   """
   many-to-many link of what groups can review for what organizations
@@ -21,6 +24,20 @@ class ReviewGroup(models.Model):
   organization = models.ForeignKey(Organization, db_index=True)
   group = models.ForeignKey(Group, db_index=True)
 
+
+  @classmethod
+  def org_groups(cls, organization_slug):
+    """
+    memo-ize orgs--it'll be a long time before we're too big for memory
+    """
+    if organization_slug not in _ORGANIZATIONS:
+        _ORGANIZATIONS[organization_slug] = list(ReviewGroup.objects.filter(
+            organization__slug=organization_slug))
+    return _ORGANIZATIONS.get(organization_slug)
+
+  @classmethod
+  def user_review_groups(cls, user):
+    return ReviewGroup.objects.filter(group__user=user)
 
 class Review(models.Model):
   content_type = models.ForeignKey(ContentType,

--- a/reviewer/static/js/reviewer.js
+++ b/reviewer/static/js/reviewer.js
@@ -74,7 +74,7 @@ Reviewer.prototype = {
     var $ = this.opt.jQuery;
     var pk = $(widget).attr('data-pk');
     if (!(this.state[pk])) {
-      this.state[pk] = {'o': widget, 'data': null};
+      this.state[pk] = {'pk': pk, 'o': widget, 'data': null};
     }
   },
   updateMissingData: function(callback) {
@@ -88,7 +88,6 @@ Reviewer.prototype = {
   },
   loadMissingData: function(pks, callback) {
     var self = this;
-    console.log(this, this.opt);
     this.$.getJSON(this.opt.apiPath + '/history/' + this.opt.organization
                    + '/?logs=1&type=' + this.opt.contentType + '&pks=' + pks.join(','))
       .then(function(data) {
@@ -131,7 +130,7 @@ Reviewer.prototype = {
       var obj = this.state[a];
       if (obj.o) {
         obj.o.innerHTML = this.render(obj);
-        this.postRender(obj.o);
+        this.postRender(obj);
       }
     }
   },
@@ -145,7 +144,7 @@ Reviewer.prototype = {
               return self.renderDecisions(schema, obj)
             }).join('')
             + '<label>Log</label><input type="text" />'
-            + '<button>Save</button>'
+            + '<button class="save">Save</button>'
             + this.renderLog(obj)
             + '</div>'
            )
@@ -154,20 +153,24 @@ Reviewer.prototype = {
   renderDecisions: function(schema, obj) {
     var prefix = this.prefix;
     var name = schema.name;
-    console.log(schema);
     return (''
             + '<div><label>'+schema.label+'</label>'
             + '<select class="review-select-'+name+'" data-pk="'+obj.pk+'" name="'+prefix+name+'_'+obj.pk+'">'
             + schema.choices.map(function(o) {
-              return '<option '+(obj[name]==o[0]?'selected':'')+' value="'+o[0]+'">'+o[1]+'</option>';
+              return '<option '+(obj.data[name]==o[0]?'selected="selected"':'')+' value="'+o[0]+'">'+o[1]+'</option>';
             }).join('')
             + '</select></div>');
   },
   renderFocus: function(){return '<div>focus</div>'},
-  postRender: function(widget) {
-    var $ = this.opt.jQuery;
-    //setup listeners:
-    //* onchange/focus: mark attention
-    //* save: saveDecision
+  postRender: function(obj) {
+    var $ = this.$;
+    var self = this;
+    $('button.save', obj.o).on('click', function(evt) {
+      evt.preventDefault(); //disable submitting page
+      //TODO: save log+review
+    });
+    $('input,select', obj.o).on('click mousedown focus', function(evt) {
+      //TODO: mark attention if different pk
+    });
   }
 };

--- a/reviewer/static/js/reviewer.js
+++ b/reviewer/static/js/reviewer.js
@@ -10,59 +10,164 @@
   * get ids from current dom
     * create fields in a good location
     * handle log/review saving
-    * handle marking attention
+    * handle marking focus
   * poll for new info
     * match dom ids with info and update
       * ?do NOT update if user is attending (or update differently)
  */
-function Reviewer() {
-  this.init(arguments);
+function Reviewer(opts) {
   this.state = {}; //keyed by object_id; has pointers to dom, and current values
-  this.attention = null; //key of object
+  this.focus = null; //key of object
   this.prefix = 'reviewer_'+parseInt(Math.random()*100) + '_';
   this.opt = {
     jQuery: window.jQuery,
     organization: null,
-    content_type: null,
-    api_path: '/review',
-    css_selector: '.review', //expects data-pk and data-type
-    schema: {
-      'review_status': [
-        ['unknown', 'unreviewed'],
-        ['good', 'good'],
-        ['bad', 'bad'],
-      ]
-    }
+    contentType: null,
+    apiPath: '/review',
+    cssSelector: '.review', //expects data-pk and data-type
+    schema: [
+      {'name': 'review_status',
+       'choices':[ ['unknown', 'unreviewed'],
+                   ['good', 'good'],
+                   ['bad', 'bad']],
+       'label': 'Review Status'
+      }
+    ]
   };
+  this.init(opts);
 }
 Reviewer.prototype = {
-  init: function(){},
-
-
+  init: function(options){
+    if (options) {
+      for (var a in options) {
+        this.opt[a] = options[a];
+      }
+    }
+    for (var b in this) {
+      if (typeof this[b] == 'function') {
+        this[b] = this[b].bind(this);
+      }
+    }
+    var $ = this.$ = this.opt.jQuery;
+  },
+  run: function() {
+    this.initReviewWidgets();
+    this.updateMissingData(this.initRenderAll);
+    // 2. render the data/initialize the widget
+    //2. start polling
+    return this;
+  },
+  saveDecision: function(evt) {
+  },
+  findReviewWidgets: function() {
+    var $ = this.opt.jQuery;
+    return $(this.opt.cssSelector);
+  },
+  initReviewWidgets: function() {
+    var self = this;
+    this.findReviewWidgets().each(function() {
+      self.loadDataFromReviewWidget(this)
+    });
+  },
+  loadDataFromReviewWidget: function(widget) {
+    //get pk, dom and => this.state
+    var $ = this.opt.jQuery;
+    var pk = $(widget).attr('data-pk');
+    if (!(this.state[pk])) {
+      this.state[pk] = {'o': widget, 'data': null};
+    }
+  },
+  updateMissingData: function(callback) {
+    var newPks = [];
+    for (var a in this.state) {
+      if (!this.state[a].data) {
+        newPks.push(a);
+      }
+    }
+    this.loadMissingData(newPks, callback);
+  },
+  loadMissingData: function(pks, callback) {
+    var self = this;
+    console.log(this, this.opt);
+    this.$.getJSON(this.opt.apiPath + '/history/' + this.opt.organization
+                   + '/?logs=1&type=' + this.opt.contentType + '&pks=' + pks.join(','))
+      .then(function(data) {
+        if (data.reviews && data.reviews.length == pks.length) {
+          // In theory, the api delivers the reviews and logs back in the same
+          // order as they were asked for.
+          // So data.logs[i] should be for pks[i], but when there
+          // hasn't been a review yet, what does redis return?
+          // Thus this is defensive and uses the review and log pk vals rather than
+          // the pk index.
+          for (var i=0,l=pks.length; i<l; i++) {
+            var rev = data.reviews[i];
+            var log = data.logs[i];
+            if (rev) {
+                if (self.state[rev.pk]) {
+                  self.state[rev.pk].data = rev;
+                }
+            } else { //no data for that pk
+              self.state[pks[i]].data = {};
+            }
+            if (log && self.state[log.pk]) {
+              self.state[rev.pk].log = log.m;
+            }
+          }
+        }
+        if (callback) {
+          callback(data);
+        }
+      });
+  },
+  pollState: function() {
+    //1. find pks with missing data
+    //2. get full data with state for them
+    //3. get current/
+    //   3.1: update state
+    //   3.2: update UI
+  },
+  initRenderAll: function() {
+    for (var a in this.state) {
+      var obj = this.state[a];
+      if (obj.o) {
+        obj.o.innerHTML = this.render(obj);
+        this.postRender(obj.o);
+      }
+    }
+  },
   //render review component for a specific field
-  render: function($) {
+  render: function(obj) {
+    var self = this;
     return (''
-      + '<div class="review-widget">'
-      + ''
-      + ''
-      + ''
-      + ''
-      + ''
-      + ''
-      + ''
-      + ''
-      + ''
-      + '</div>'
-    )
+            + '<div class="review-widget">'
+            + this.renderFocus()
+            + this.opt.schema.map(function(schema) {
+              return self.renderDecisions(schema, obj)
+            }).join('')
+            + '<label>Log</label><input type="text" />'
+            + '<button>Save</button>'
+            + this.renderLog(obj)
+            + '</div>'
+           )
   },
-  renderLog: function(){},
-  renderDecisions: function(name, schema, obj) {
+  renderLog: function(){return '<div>Log</div>'},
+  renderDecisions: function(schema, obj) {
     var prefix = this.prefix;
-    '<select class="review-'+name+'" onchange="" data-pk="'+obj.pk+'" name="'+prefix+name++obj.pk+'">'
-    + schema.map(function(o) {
-      return '<option '+(obj[name]==o[0]?'selected':'')+' value="'+o[0]+'">'+o[1]+'</option>';
-    }).join('')
-    + '</select>';
+    var name = schema.name;
+    console.log(schema);
+    return (''
+            + '<div><label>'+schema.label+'</label>'
+            + '<select class="review-select-'+name+'" data-pk="'+obj.pk+'" name="'+prefix+name+'_'+obj.pk+'">'
+            + schema.choices.map(function(o) {
+              return '<option '+(obj[name]==o[0]?'selected':'')+' value="'+o[0]+'">'+o[1]+'</option>';
+            }).join('')
+            + '</select></div>');
   },
-  renderAttention: function(){}
-}
+  renderFocus: function(){return '<div>focus</div>'},
+  postRender: function(widget) {
+    var $ = this.opt.jQuery;
+    //setup listeners:
+    //* onchange/focus: mark attention
+    //* save: saveDecision
+  }
+};

--- a/reviewer/templates/reviewer/admin/reviewerorganizationfilter.html
+++ b/reviewer/templates/reviewer/admin/reviewerorganizationfilter.html
@@ -12,10 +12,10 @@
 {% else %}
   {# chosen, or just one option #}
 <script>
- var reviewState = new Reviewer({organization: "{{spec.get_slug}}",
-                                 schema:'{{spec.review_schema_json|safe}}',
-                                 content_type: {{spec.content_type.id}},
-                                });
- 
+  var reviewState = (new Reviewer({organization: "{{spec.get_slug}}",
+                                   schema: {{spec.review_schema_json|safe}},
+                                   contentType: {{spec.content_type.id}},
+                                   jQuery: window.jQuery || django.jQuery
+                                  })).run();
 </script>
 {% endif %}

--- a/reviewer/templates/reviewer/admin/reviewerorganizationfilter.html
+++ b/reviewer/templates/reviewer/admin/reviewerorganizationfilter.html
@@ -1,0 +1,21 @@
+{% load static %}
+<script src="{% static 'js/reviewer.js' %}"></script>
+
+{% if not spec.value %}
+  {# need to offer options #}
+  <label>Review for</label>
+  <ul>
+    {% for c in choices %}
+    <li><a href="{{c.query_string|iriencode}}">{{c.display}}</a>{% if c.selected %} (current){% endif %}</li>
+    {% endfor %}
+  </ul>
+{% else %}
+  {# chosen, or just one option #}
+<script>
+ var reviewState = new Reviewer({organization: "{{spec.get_slug}}",
+                                 schema:'{{spec.review_schema_json|safe}}',
+                                 content_type: {{spec.content_type.id}},
+                                });
+ 
+</script>
+{% endif %}

--- a/reviewer/urls.py
+++ b/reviewer/urls.py
@@ -6,7 +6,7 @@ urlpatterns = [
         name='reviewer_current'),
     url(r'^history/(?P<organization>[-.\w]+)/?$', views.get_review_history,
         name='reviewer_history'),
-    url(r'^(?P<organization>[-.\w]+)/(?P<content_type>\w+)/(?P<pk>\w+)/visit/?$', views.mark_attention,
+    url(r'^focus/(?P<organization>[-.\w]+)/(?P<content_type>\w+)/(?P<pk>\w+)/?$', views.mark_focus,
         name='reviewer_visit'),
     url(r'^(?P<organization>[-.\w]+)/(?P<content_type>\w+)/?$', views.save_review,
         name='reviewer_save'),

--- a/reviewer/views.py
+++ b/reviewer/views.py
@@ -16,7 +16,7 @@ from reviewer.models import Review, ReviewLog, ReviewGroup
   per-organization.  Here's the list:
 
   Hashes:
-   <organization>_marks key=username val=<json array of 4 items>
+   <organization>_focus key=username val=<json array of 4 items>
    <organization>_reviews key=<content_type>_<pk> val=<json obj>
   Lists:
    #slightly redundant to reviews, but focused on recent updates
@@ -26,18 +26,6 @@ from reviewer.models import Review, ReviewLog, ReviewGroup
    and will leverage django-cachalot
 """
 
-_ORGANIZATIONS = {}  # by slug
-def _get_org_groups(organization_slug):
-    """
-    memo-ize orgs--it'll be a long time before we're too big for memory
-    """
-    if organization_slug not in _ORGANIZATIONS:
-        _ORGANIZATIONS[organization_slug] = list(ReviewGroup.objects.filter(
-            organization__slug=organization_slug))
-    grps = _ORGANIZATIONS[organization_slug]
-    if not grps:
-        raise Http404("nope") #if the org doesn't have any review groups its dead
-    return grps
 
 def reviewgroup_auth(view_func):
     """
@@ -45,7 +33,7 @@ def reviewgroup_auth(view_func):
     Note: Assumes that `organization` is the first view parameter (after request)
     """
     def wrapped(request, organization, *args, **kw):
-        allowed = _get_org_groups(organization)
+        allowed = ReviewGroup.org_groups(organization)
         allowed_groups = set([x.group_id for x in allowed])
         group_ids = set(request.user.groups.values_list('id', flat=True))
         if not group_ids.intersection(allowed_groups) \
@@ -68,7 +56,7 @@ def save_review(request, organization, content_type):
         log_message = request.POST.get('log')
         if content_type and pk and len(decisions_str) >= 3\
            and ':' in decisions_str:
-            org = _get_org_groups(organization)
+            org = ReviewGroup.org_groups(organization)
             ct = ContentType.objects.get_for_id(int(content_type))
             # make sure the object exists
             obj = ct.get_object_for_this_type(pk=pk)
@@ -132,13 +120,13 @@ def get_review_history(request, organization):
 
 
 @reviewgroup_auth
-def mark_attention(request, organization, content_type, pk):
+def mark_focus(request, organization, content_type, pk):
     # POST/DELETE mark whether someone is looking at this
     # takes the reviewer name from login username
     # saved object: [<type>, <pk>, <name>, <timestamp>]
-    # HSET <organization>_marks <name> <object>
+    # HSET <organization>_focus <name> <object>
     redis = get_redis_connection("default")
-    rkey = '{}_marks'.format(organization)
+    rkey = '{}_focus'.format(organization)
     if request.method == "POST":
         name = request.user.get_full_name()
         redis.hset(rkey, name[:128], json.dumps([
@@ -146,21 +134,21 @@ def mark_attention(request, organization, content_type, pk):
             int(time.time())
         ]))
         if reds.hlen(rkey) > 50:
-            _clear_old_marks(organization)
+            _clear_old_focus(organization)
     elif request.method == "DELETE":
         redis.hdel(rkey, name[:128])
     return HttpResponse("ok")
 
 
-def _clear_old_marks(organization, max=50):
+def _clear_old_focus(organization, max=50):
     too_old = int(time.time()) - 60*60*2  # 2 hours
     redis = get_redis_connection("default")
-    rkey = '{}_marks'.format(organization)
-    marks = sorted(
+    rkey = '{}_focus'.format(organization)
+    focus = sorted(
         [json.loads(v.decode('utf-8'))
          for v in redis.hgetall(rkey).values()],
         key=lambda m: m[3], reverse=True)
-    to_delete = [m[2] for i, m in enumerate(marks)
+    to_delete = [m[2] for i, m in enumerate(focus)
                  if i > max or m[3] < too_old]
     if to_delete:
         redis.hdel(rkey, *to_delete)
@@ -177,7 +165,7 @@ def current_review_state(request, organization):
          "<review key>":"<decision>",...
         }, ...
       ],
-      marks: [
+      focus: [
         ["event", <pk>, "<name>", <timestamp in epoch seconds>],
         ...
       ]
@@ -186,11 +174,13 @@ def current_review_state(request, organization):
     redis = get_redis_connection("default")
     itemskey = '{}_items'.format(organization)
     items = redis.lrange(itemskey, 0, 50)
-    marks = redis.hgetall('{}_marks'.format(organization)).values()
+    focus = redis.hgetall('{}_focus'.format(organization)).values()
     if not items:
         # TODO: get them from db and save them to redis
         # if no items in db, then lpush empty string to items
-        org = _get_org_groups(organization)
+        org = ReviewGroup.org_groups(organization)
+        if not org:
+            return HttpResponseForbidden('nope')
         #maybe just get most recent review for each object
         query = Review.objects.filter(organization_id=org[0].organization_id).order_by('-id')
         try:
@@ -226,7 +216,7 @@ def current_review_state(request, organization):
             # we will just ignore until the queue fills up and it gets bumped
             items.pop()
 
-    return HttpResponse("""{"objects":[%s],"marks":[%s]}""" % (
+    return HttpResponse("""{"objects":[%s],"focus":[%s]}""" % (
         ','.join([o.decode('utf-8') for o in items]),
-        ','.join([m.decode('utf-8') for m in marks])
+        ','.join([m.decode('utf-8') for m in focus])
     ), content_type='application/json')


### PR DESCRIPTION
This doesn't do anything yet interface-wise, but intersects with @sreynen 's admin work, so thought it should be reviewed.

Basically if someone is part of an organization reviewer group, we auto-filter on the organization, and also load up an instance of `Reviewer()` with the right context variables (content type, organization)