### PR TITLE
add send login link to hosts button for AK events

### DIFF
--- a/event_exim/connectors/actionkit_api.py
+++ b/event_exim/connectors/actionkit_api.py
@@ -3,6 +3,8 @@ from itertools import chain
 import json
 import re
 
+from django.template.loader import render_to_string
+
 from actionkit.api.event import AKEventAPI
 from actionkit.api.user import AKUserAPI
 from actionkit.utils import generate_akid
@@ -296,7 +298,7 @@ class Connector:
                 return '{}/admin/events/event/?campaign={cid}&event_id={eid}'.format(
                     self.base_url, cid=cid, eid=event.organization_source_pk)
 
-    def get_host_event_link(self, event, edit_access=False):
+    def get_host_event_link(self, event, edit_access=False, host_id=False):
         if event.status != 'active':
             return None
         jsondata = event.source_json_data
@@ -309,12 +311,22 @@ class Connector:
         host_link = '/event/{create_page}/{event_id}/host/'.format(
             create_page=create_page,
             event_id=event.organization_source_pk)
-        if edit_access and self.cohost_id and self.akapi.secret:
+
+        if not host_id:
+            host_id = self.cohost_id
+
+        if edit_access and host_id and self.akapi.secret:
             #easy memoization for a single user
-            token = _LOGIN_TOKENS.get(self.cohost_id, False)
+            token = _LOGIN_TOKENS.get(host_id, False)
             if token is False:
-                token = self.akapi.login_token(self.cohost_id)
-                _LOGIN_TOKENS[self.cohost_id] = token
+                token = self.akapi.login_token(host_id)
+                _LOGIN_TOKENS[host_id] = token
             if token:
                 host_link = '/login/?i={}&l=1&next={}'.format(token, host_link)
         return '{}{}'.format(self.base_url, host_link)
+
+    def get_extra_event_management_html(self, event):
+        return render_to_string(
+            'event_exim/actionkit-extra_event_management.html',
+            {'event_id':event.id,
+             'link':'/api/actionkit/hostloginreminder/%s/' % event.id})

--- a/event_exim/templates/event_exim/actionkit-extra_event_management.html
+++ b/event_exim/templates/event_exim/actionkit-extra_event_management.html
@@ -1,0 +1,25 @@
+<a id="send-host-login-link--{{event_id}}" href="{{link|safe}}" class="btn btn-default">Send login link to hosts</a>
+<span id="send-host-login-link-status--{{event_id}}" class="hidden"></span>
+<script>
+$('#send-host-login-link--{{event_id}}').click(function() {
+    var $link = $('#send-host-login-link--{{event_id}}');
+    var $status = $('#send-host-login-link-status--{{event_id}}');
+    $status
+        .text('Sending ...')
+        .attr('class', 'alert alert-warning');
+    $.getJSON($link.attr('href'), function(data) {
+        console.log(data);
+        console.log(data.result);
+        if (data.result == 'success') {
+            $status
+                .text('Sent')
+                .attr('class', 'alert alert-success');
+        } else {
+            $status
+                .text('Error')
+                .attr('class', 'alert alert-danger');
+        }
+    });
+    return false;
+});
+</script>

--- a/event_review/admin.py
+++ b/event_review/admin.py
@@ -56,12 +56,14 @@ def event_list_display(obj, onecol=False):
           <div class="col-md-6">
             <div><b>Private Phone:</b> {private_phone}</div>
             <div><b>Event Status:</b> {active_status}</div>
+            {extra_html}
             {review_widget}
           </div>
         """,
         private_phone=phone_format(obj.private_phone),
         active_status=obj.status,
-        review_widget=review_widget(obj, obj.organization_host_id)
+        review_widget=review_widget(obj, obj.organization_host_id),
+        extra_html=obj.extra_management_html()
         )
     return format_html("""
         <div class="row">
@@ -96,10 +98,6 @@ def event_list_display(obj, onecol=False):
                 if obj.is_private else '',
         host=host_format(obj),
         second_col=second_col,
-        #review_status=obj.organization_status_review,
-        #prep_status=obj.organization_status_prep,
-        #notes=mark_safe('<textarea rows="5" class="form-control" readonly>%s</textarea>' % obj.notes)
-        #    if obj.notes else None,
         description = mark_safe('<textarea rows="5" class="form-control" readonly>%s</textarea>' % obj.public_description)
             if obj.public_description else None)
 

--- a/event_review/templates/event_review/email-actionkit_host_login.html
+++ b/event_review/templates/event_review/email-actionkit_host_login.html
@@ -1,0 +1,7 @@
+Hi {{host_name}},
+
+Someone (probably you) requested a link to login to your {{source}} host tools. You can login and access your host tools here:
+
+{{link|safe}}
+
+If you didn't request this, you don't need to do anything.

--- a/event_review/urls.py
+++ b/event_review/urls.py
@@ -1,0 +1,8 @@
+from django.conf.urls import include, url
+from . import views
+
+urlpatterns = [
+    url(r'^api/actionkit/hostloginreminder/(?P<event_id>[-.\w]+)/$',
+        views.send_actionkit_host_login_reminder,
+        name='event_review_actionkit_hostloginreminder'),
+]

--- a/event_review/views.py
+++ b/event_review/views.py
@@ -1,0 +1,34 @@
+import json
+
+from django.conf import settings
+from django.core.mail import EmailMultiAlternatives
+from django.http import HttpResponse
+from django.template.loader import render_to_string
+
+from actionkit.api.user import AKUserAPI
+from event_store.models import Event
+from event_exim.connectors.actionkit_api import Connector
+
+def send_actionkit_host_login_reminder(request, event_id):
+    result = 'failed to send'
+
+    if settings.FROM_EMAIL:
+        event = Event.objects.filter(id=event_id).first()
+        if event:
+            src = event.organization_source
+            if src and hasattr(src.api, 'get_host_event_link'):
+                host_link = src.api.get_host_event_link(event, edit_access=True, host_id=event.organization_host.member_system_pk)
+                email_subject = '%s Event Host Login Link' % src.name
+                message = message = render_to_string(
+                    'event_review/email-actionkit_host_login.html',
+                    {'host_name': event.organization_host.name,
+                     'source': src.name,
+                     'link': host_link})
+                mailmessage = EmailMultiAlternatives(email_subject, message, settings.FROM_EMAIL, [event.organization_host.email])
+                mailmessage.send()
+                result = 'success'
+
+    response_json = json.dumps({
+        'result': result,
+    })
+    return HttpResponse(response_json, content_type='application/json')

--- a/event_store/models.py
+++ b/event_store/models.py
@@ -205,6 +205,12 @@ class Event(models.Model):
         if src and hasattr(src.api, 'get_host_event_link'):
             return src.api.get_host_event_link(self, edit_access=edit_access)
 
+    def extra_management_html(self):
+        src = self.organization_source
+        if src and hasattr(src.api, 'get_extra_event_management_html'):
+            return src.api.get_extra_event_management_html(self)
+        return ''
+
     def handle_rsvp(self):
         return None #organization can implement
 

--- a/eventroller/settings.py
+++ b/eventroller/settings.py
@@ -167,6 +167,7 @@ USE_TZ = False
 
 STATIC_URL = os.environ.get('STATIC_URL', '/static/')
 STATIC_ROOT = '%s/static_build' % BASE_DIR
+FROM_EMAIL = os.environ.get('FROM_EMAIL', False)
 
 if os.environ.get('LAMBDA_ZAPPA'):
     SECRET_KEY = os.environ.get('DJANGO_BASE_SECRET', SECRET_KEY)

--- a/eventroller/urls.py
+++ b/eventroller/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     url(r'^review/', include('reviewer.urls')),
     url(r'^api/v1/', include('event_exim.urls')),
     url('^', include('django.contrib.auth.urls')),
+    url('^', include('event_review.urls')),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
ActionKit event hosts don't always know how to get to their event edit page, so this adds a way for reviewers to quickly send hosts an auto-login link.