### PR TITLE
allow hidden organizations for the purposes of specialized review access models

### DIFF
--- a/reviewer/filters.py
+++ b/reviewer/filters.py
@@ -59,7 +59,9 @@ class ReviewerOrganizationFilter(SimpleListFilter):
         # we need this to save the right content type with the review api
         self.content_type = ContentType.objects.get_for_model(model_admin.model)
         user = request.user
-        return list(set(ReviewGroup.user_review_groups(request.user).values_list('organization_id', 'organization__title')))
+        return list(set(ReviewGroup.user_review_groups(request.user)
+                        .exclude(organization__slug__endswith='hidden')
+                        .values_list('organization_id', 'organization__title')))
 
     def queryset(self, request, queryset):
         org = self.value()


### PR DESCRIPTION
This is a hack to allow us to avoid showing people multiple organizations that are used for reviewer access of specific content types.