### PR TITLE
missing filter for updated review model might be causing bulk tag del…

### DIFF
--- a/reviewer/models.py
+++ b/reviewer/models.py
@@ -108,7 +108,8 @@ class Review(models.Model):
             reviewer=reviewer,
             key=key,
             content_type=content_type,
-            object_id__in=obj_ids
+            object_id__in=obj_ids,
+            is_current=True
         ).update(is_current=False)
         cls.bulk_clear_review_cache(obj_ids, content_type.id, organization)
         return result


### PR DESCRIPTION
This seems to fix a bulk tagging bug where if there were multiple instances of a tag on the same user, only one would be updated on bulk delete. Functionally completes https://github.com/MoveOnOrg/connier/pull/122