### PR TITLE
Follow-up note/message sending visibility PR

### DIFF
--- a/event_review/admin.py
+++ b/event_review/admin.py
@@ -219,7 +219,7 @@ class EventAdmin(MessageSendingAdminMixin, admin.ModelAdmin, EventDisplayAdminMi
 
     ## BEGIN EventAdmin Message Sending
     send_a_message_placeholder = 'Optional message to host. Email will include a link to manage the event.'
-    def message_template(self, message, event):
+    def message_template(self, message, event, user=None):
         """
         NOTE: This takes a while to render, almost entirely because
           get_host_event_link needs to get a login token by AK API, which takes some time.

--- a/reviewer/admin.py
+++ b/reviewer/admin.py
@@ -1,8 +1,16 @@
 from django.contrib import admin
 
-from reviewer.models import ReviewGroup
+from reviewer.models import ReviewGroup, ReviewLog
 
 @admin.register(ReviewGroup)
 class ReviewGroupAdmin(admin.ModelAdmin):
-    #list_display = ['organization', 'group']
-    pass
+    list_display = ['organization', 'group', 'visibility_level']
+
+@admin.register(ReviewLog)
+class ReviewGroupAdmin(admin.ModelAdmin):
+    list_display = ['content_type', 'object_id', 'subject',
+                    'reviewer',
+                    'created_at',
+                    'visibility_level',
+                    'log_type', 'message']
+    search_fields = ['subject', 'object_id', 'message']

--- a/reviewer/message_sending.py
+++ b/reviewer/message_sending.py
@@ -211,8 +211,8 @@ class MessageSendingAdminMixin:
                 organization_slug = orgslugs[0]
 
         if log_type in ('message', 'bulkmsg'):
-            howmany = ReviewLog.objects.filter(reviwer=request.user,
-                                     log_type__in=('message', 'bulkmsg'))
+            howmany = ReviewLog.objects.filter(reviewer=request.user,
+                                               log_type__in=('message', 'bulkmsg'))
             curtime = datetime.datetime.now()
             weekcount = howmany.filter(created_at__gte=curtime-datetime.timedelta(days=7)).count()
             daycount = howmany.filter(created_at__gte=curtime-datetime.timedelta(days=1)).count()

--- a/reviewer/message_sending.py
+++ b/reviewer/message_sending.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import random
 
@@ -68,7 +69,8 @@ class MessageSendingAdminMixin:
 
     def send_message(self, request, organization, obj_id):
         result = 'failed to send'
-        if not ReviewGroup.user_allowed(request.user, organization):
+        if not ReviewGroup.user_allowed(request.user, organization)\
+           or not request.user.has_perm('reviewer.message_sending'):
             result = 'permission denied'
         elif request.method == 'POST' and self.message_send_ready(organization, request):
             obj = self.message_obj_lookup(obj_id, organization, request)
@@ -90,7 +92,7 @@ class MessageSendingAdminMixin:
         """
         return self.model.objects.filter(pk=obj_id).first()
 
-    def message_template(self, message, obj):
+    def message_template(self, message, obj, user=None):
         return {
             'to': obj.email,
             'subject': 'Message about {}'.format(str(obj)), # TODO? should we make it a setting?
@@ -108,17 +110,15 @@ class MessageSendingAdminMixin:
         bulktypes = {'message': 'bulkmsg', 'note': 'bulknote'}
         messages = []
         review_logs = []
-        if log_type == 'message':
+        if log_type in ('message', 'bulkmsg'):
             for obj in objects:
-                print(obj.id, obj)
-                message_dict = self.message_template(message, obj)
+                message_dict = self.message_template(message, obj, user)
                 messages.append(create_message(**message_dict))
             if actually_send:
                 connection = get_mail_connection()
                 if hasattr(connection, 'open'):
                     connection.open()
                 connection.send_messages(messages)
-            print(messages) # TODO remove debug
         # save messages into reviewlog or similar
         if message and user:
             msg_count = len(objects)
@@ -132,7 +132,8 @@ class MessageSendingAdminMixin:
                                              subject=subject_id,
                                              organization_id=org.id,
                                              reviewer=user,
-                                             log_type=log_type if msg_count == 1 else bulktypes.get(log_type),
+                                             log_type=(log_type if msg_count == 1
+                                                       else bulktypes.get(log_type, log_type)),
                                              visibility_level=int(visibility),
                                              message=message))
             if review_logs:
@@ -193,7 +194,10 @@ class MessageSendingAdminMixin:
         opts = modeladmin.model._meta
         action_checkbox_name="_selected_action"
         app_label = opts.app_label
+        no_continue_message = ''
         perms_needed = not request.user.has_perm('reviewer.{}'.format(action))
+        if perms_needed:
+            no_continue_message = 'Contact a site administrator about getting permission to {}.'.format(action)
         count = queryset.count()
         max_apply = getattr(settings, "BULK_NOTEMESSAGE_MAX", 200)
 
@@ -205,6 +209,19 @@ class MessageSendingAdminMixin:
                         .distinct())
             if len(orgslugs) == 1:
                 organization_slug = orgslugs[0]
+
+        if log_type in ('message', 'bulkmsg'):
+            howmany = ReviewLog.objects.filter(reviwer=request.user,
+                                     log_type__in=('message', 'bulkmsg'))
+            curtime = datetime.datetime.now()
+            weekcount = howmany.filter(created_at__gte=curtime-datetime.timedelta(days=7)).count()
+            daycount = howmany.filter(created_at__gte=curtime-datetime.timedelta(days=1)).count()
+            max_daycount = getattr(settings, 'BULK_NOTEMESSAGE_DAY_MAX', 200)
+            max_weekcount = getattr(settings, 'BULK_NOTEMESSAGE_WEEK_MAX', 200)
+            if (daycount + count) > max_daycount:
+                no_continue_message = 'This exceeds your daily contact count of {}.'.format(max_daycount)
+            elif (weekcount + count) > max_weekcount:
+                no_continue_message = 'This exceeds your weekly contact count of {}.'.format(max_weekcount)
 
         if not perms_needed and count and count <= max_apply:
             message = request.POST.get('message','')
@@ -233,6 +250,7 @@ class MessageSendingAdminMixin:
             count=count,
             max_apply=max_apply,
             perms_lacking=perms_needed,
+            no_continue_message=no_continue_message,
             opts=opts,
             action_checkbox_name=action_checkbox_name,
             media=modeladmin.media,

--- a/reviewer/templates/reviewer/admin/bulk_content_action.html
+++ b/reviewer/templates/reviewer/admin/bulk_content_action.html
@@ -27,9 +27,9 @@
 
 {% block content %}
 
-{% if perms_lacking %}
+{% if no_continue_message %}
     <p class="alert alert-danger">
-      Contact a site administrator about getting permission to {{action}}.
+      {{no_continue_message}}
     </p>
 {% elif count > max_apply %}
     <p class="alert alert-danger">


### PR DESCRIPTION
* When a user's visibility_level reviewgroup is 0 they can't see anything but their own.  For 1 and above, people can see anything
* Implement configurable maxdaily and maxweekly values for sending
* Add an admin view (only for real admins -- and maybe full staff) to review reviewlogs through a separate interface.  just a stub for convenience
* Prep message_template() to get a user object, so we can be ready to do something different if it's a staff user (e.g. reply-to or whatever) -- I'm going to wait for copy to go further on how this should work.