### PR TITLE
include cohosts in messages to host(s) and include contact details

### DIFF
--- a/event_exim/connectors/actionkit_api.py
+++ b/event_exim/connectors/actionkit_api.py
@@ -223,7 +223,7 @@ class Connector:
         def cleanchars(val, key):
             if isinstance(val, str):
                 if key == 'state':
-                    if not re.match(r'[A-Z][A-Z]', val.upper()):
+                    if not re.match(r'^[A-Z][A-Z]$', val.upper()):
                         # indication of corrupted state
                         hackattempt = True
                         return 'XX'

--- a/event_store/models.py
+++ b/event_store/models.py
@@ -4,6 +4,7 @@ import re
 
 from django.db import models
 from django.contrib.auth.models import User, Group
+from django.utils.html import format_html, mark_safe
 
 class Organization(models.Model):
     title = models.CharField(max_length=765)
@@ -219,6 +220,14 @@ class Event(models.Model):
             'review_status': self.organization_status_review,
             'prep_status': self.organization_status_prep,
         }
+
+    @classmethod
+    def phone_format(cls, phone):
+        return format_html('<span style="white-space: nowrap">{}</span>',
+                           re.sub(r'^(\d{3})(\d{3})(\d{4})', '(\\1) \\2-\\3',
+                                  phone))
+
+
 
     @classmethod
     def political_scope_display(cls, political_scope):

--- a/reviewer/message_sending.py
+++ b/reviewer/message_sending.py
@@ -281,13 +281,14 @@ def create_message(to=None, subject=None, message_text=None, message_html='',
                    reply_to=None, headers=None,
                    actually_send=False, **kwargs):
     extra_args = {}
+    to_list = to if isinstance(to, list) else [to]
     if reply_to:
         extra_args['reply_to'] = [reply_to]  # EmailMultiAlternatives takes a list
     if headers:
         extra_args['headers'] = headers
     if not from_line and from_name and from_email:
         from_line = '"{}" <{}>'.format(from_name.replace('"', '\\"'), from_email)
-    mailmessage = EmailMultiAlternatives(subject, message_text, from_line, [to],
+    mailmessage = EmailMultiAlternatives(subject, message_text, from_line, to_list,
                                          **extra_args)
     if message_html:
         mailmessage.attach_alternative(message_html, "text/html")


### PR DESCRIPTION
When hosts are contacted by email, then cohosts are included in the email.  It also displays cohost email and phone when available from the interface.