### PR TITLE
Update review status from "reviewed" to "claimed"

### DIFF
--- a/event_store/models.py
+++ b/event_store/models.py
@@ -68,7 +68,7 @@ class Activist(models.Model):
 
 
 EVENT_REVIEW_CHOICES = ((None, 'New'),
-                        ('reviewed', 'Reviewed'),
+                        ('reviewed', 'Claimed'),
                         ('vetted', 'Vetted'),
                         ('questionable', 'Questionable'),
                         ('limbo', 'Limbo'))


### PR DESCRIPTION
This changes the display value, but doesn't change the machine name to avoid invalidating existing records.