### PR TITLE
'union' is not supported in Django 1.10

### DIFF
--- a/event_exim/models.py
+++ b/event_exim/models.py
@@ -283,7 +283,7 @@ class EventDupeGuesses(models.Model):
                 dupe_id__isnull=True,
                 status='active'
             )
-            dupe_events = dupe_events.union(dupes)
+            dupe_events = dupe_events | dupes
         return dupe_events
 
     @ staticmethod


### PR DESCRIPTION
The union operator was only added in Django 1.11, while this repository runs on 1.10

This should fix the constant large number of errors we keep getting in Datadog.